### PR TITLE
Expose Kernel from Zephyr

### DIFF
--- a/kernel-modules/synchronous-api/src/main/java/io/zephyr/cli/DefaultZephyr.java
+++ b/kernel-modules/synchronous-api/src/main/java/io/zephyr/cli/DefaultZephyr.java
@@ -147,4 +147,9 @@ public class DefaultZephyr implements Zephyr {
     }
     kernel.getModuleManager().prepare(group).commit().toCompletableFuture().get();
   }
+
+  @Override
+  public Kernel getKernel() {
+    return kernel;
+  }
 }

--- a/kernel-modules/synchronous-api/src/main/java/io/zephyr/cli/Zephyr.java
+++ b/kernel-modules/synchronous-api/src/main/java/io/zephyr/cli/Zephyr.java
@@ -2,6 +2,7 @@ package io.zephyr.cli;
 
 import io.zephyr.kernel.Coordinate;
 import io.zephyr.kernel.Module;
+import io.zephyr.kernel.core.Kernel;
 import io.zephyr.kernel.module.ModuleLifecycle;
 import java.net.URL;
 import java.util.Collection;
@@ -40,4 +41,6 @@ public interface Zephyr {
   void startup();
 
   void restart();
+
+  Kernel getKernel();
 }


### PR DESCRIPTION
I need access to the Kernel when using `io.zephyr.cli.Zephyr` as I wish to add event listeners to handle the case where plugin installations fail.