### PR TITLE
Handle serviceRegistry.getRegistrations returning null

### DIFF
--- a/kernel-core/src/main/java/io/zephyr/kernel/core/DefaultPluginContext.java
+++ b/kernel-core/src/main/java/io/zephyr/kernel/core/DefaultPluginContext.java
@@ -149,9 +149,12 @@ public class DefaultPluginContext implements ModuleContext {
       val serviceRegistry = kernel.getServiceRegistry();
       val result = new ArrayList<ServiceReference<T>>();
       for (val module : moduleManager.getModules(Lifecycle.State.Active)) {
-        for (val registration : serviceRegistry.getRegistrations(module)) {
-          if (registration.provides(type)) {
-            result.add((ServiceReference<T>) registration.getReference());
+        val set = serviceRegistry.getRegistrations(module);
+        if (set != null) {
+          for (val registration : set) {
+            if (registration.provides(type)) {
+              result.add((ServiceReference<T>) registration.getReference());
+            }
           }
         }
       }


### PR DESCRIPTION
Sometimes serviceRegistry.getRegistrations can return null and a NPE occurs.

This is one solution - which handles the null value.  Another option would be to return an empty `ServiceRegistrationSet`